### PR TITLE
Fix venv activation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Getting Started
 1. Install [homebrew](http://brew.sh/) with the command from the site.
 2. `brew install uv` to install [uv](https://docs.astral.sh/uv/).
 3. `uv venv --python 3.12`
-6. `source venv/bin/activate`
+6. `source .venv/bin/activate`
 5. `uv pip install ansible`
 6. `./playbook.yml`
 


### PR DESCRIPTION
The default venv name generated by uv is [.venv](https://docs.astral.sh/uv/pip/environments/#creating-a-virtual-environment) and it's the name that is git ignored so I updated the readme instructions