### PR TITLE
Add `changed_when` conditions to uv commands

### DIFF
--- a/roles/adam_mac/tasks/installs.yml
+++ b/roles/adam_mac/tasks/installs.yml
@@ -56,6 +56,8 @@
     3.11
     3.12
     3.13
+  register: uv_python_install
+  changed_when: "'All requested versions already installed' not in uv_python_install.stderr"
   tags:
   - uv
 
@@ -68,6 +70,8 @@
     {% for w in item.with %}--with {{ w }}{% endfor %}
     {% endif %}
   loop: '{{ uv_tools }}'
+  register: uv_tool_install
+  changed_when: "'already installed' not in uv_tool_install.stderr"
   tags:
   - uv
 
@@ -79,11 +83,15 @@
     {% for w in item.with %}--upgrade-package {{ w }}{% endfor %}
     {% endif %}
   loop: '{{ uv_tools }}'
+  register: uv_upgrade
+  changed_when: "'Nothing to upgrade' not in uv_upgrade.stderr"
   tags:
   - uv
 
 - name: uv prune cache
   command: uv cache prune
+  register: uv_prune
+  changed_when: "'Removed' in uv_prune.stderr"
   tags:
   - uv
 


### PR DESCRIPTION
Without it, ansible always report the task as "changed" even for noops. 
With it, the output better flagged tools that are upgraded:
![image](https://github.com/user-attachments/assets/b5cffb7f-1954-4e27-97a9-fed545b569be)

This solves this ansible-lint issue https://ansible.readthedocs.io/projects/lint/rules/no-changed-when/

I would have preferred checks on the return code but it always return 0 so I matched the stderr output