### PR TITLE
Remove python related packages from brew (duplicates with uv) 

### DIFF
--- a/roles/adam_mac/tasks/dotfiles.yml
+++ b/roles/adam_mac/tasks/dotfiles.yml
@@ -4,10 +4,7 @@
     state: directory
   loop:
   - innotop
-  - ipython
-  - ipython/profile_default
   - ipython/profile_default/startup
-  - config
   - config/git
   - config/pip
   - config/zed

--- a/roles/adam_mac/vars/main.yml
+++ b/roles/adam_mac/vars/main.yml
@@ -47,9 +47,7 @@ homebrew_packages:
 - percona-toolkit
 - pkg-config
 - postgresql@16
-- pre-commit
 - pwgen
-- python
 - qpdf
 - readline
 - rg


### PR DESCRIPTION
This removes `pre-commit` and `python` from the brew packages since they are managed via uv now 

Also slightly simplify dotfiles directory creation because nested dirs are created automatically when giving a path with multiple `/`.