### PR TITLE
Make sure sanity checks are always run

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,7 @@
 #!/usr/bin/env ansible-playbook
 - hosts: localhost
   connection: local
+  tags: always
   tasks:
   - debug:
       msg: Check we are running in the directory of the script


### PR DESCRIPTION
Without this, running the playbook with `--tags brew` for ex skips this check which I believe is not intended behavior ?